### PR TITLE
[FLINK-30578][build] Publish SBOM for externalized connectors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -629,6 +629,19 @@ under the License.
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.cyclonedx</groupId>
+                    <artifactId>cyclonedx-maven-plugin</artifactId>
+                    <version>2.7.3</version>
+                    <executions>
+                        <execution>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>makeBom</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
## What is the purpose of the change
The original PR which modified the flink-parent: #https://github.com/apache/flink/pull/21606

This PR aims to publish SBOM artifacts.

- Here is an article to give some context: [article](https://www.activestate.com/blog/why-the-us-government-is-mandating-software-bill-of-materials-sbom/)

Software Bill of Materials (SBOM) are additional artifacts containing the aggregate of all direct and transitive dependencies of a project. The US Government (based on NIST recommendations) currently accepts only the three most popular SBOM standards as valid, namely: [CycloneDX](https://cyclonedx.org/), [Software Identification (SWID) tag](https://csrc.nist.gov/projects/Software-Identification-SWID), [Software Package Data Exchange® (SPDX)](https://spdx.dev/).

This PR uses [CycloneDX maven plugin](https://github.com/CycloneDX/cyclonedx-maven-plugin), a lightweight software bill of materials (SBOM) standard designed for use in application security contexts and supply chain component analysis.

BOM files get automatically published on maven deploy.

## Brief change log
- Add `cyclonedx-maven-plugin plugin` to the `flink-connector-parent` pom

## Verifying this change
- Checkout this PR and build it, then
- Clone one of the connector repository,
- adjust the `<parent><groupId>` to `org.apache.flink` in its pom,
- define the `org.cyclonedx` plugin in the plugin section of the connector (groupId/artifactId/version; other configuration stays in parent),
- build it,
- verify plugin results:

Each `jar` file will have two corresponding files: `xxx-cyclonedx.xml` and `xxx-cyclonedx.json` :tada:
Example: (run this in your cloned connector repo)
```
$ mvn install -DskipTests
...
[INFO] Installing /Users/zsomborchikan/Desktop/flink_upstream/flink-connector-jdbc/flink-connector-jdbc/target/target/bom.xml to /Users/zsomborchikan/.m2/repository/org/apache/flink/flink-connector-jdbc/3.1-SNAPSHOT/flink-connector-jdbc-3.1-SNAPSHOT-cyclonedx.xml
[INFO] Installing /Users/zsomborchikan/Desktop/flink_upstream/flink-connector-jdbc/flink-connector-jdbc/target/target/bom.json to /Users/zsomborchikan/.m2/repository/org/apache/flink/flink-connector-jdbc/3.1-SNAPSHOT/flink-connector-jdbc-3.1-SNAPSHOT-cyclonedx.json
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Flink : Connectors : JDBC : Parent 3.1-SNAPSHOT:
[INFO] 
[INFO] Flink : Connectors : JDBC : Parent ................. SUCCESS [  1.970 s]
[INFO] Flink : Connectors : JDBC .......................... SUCCESS [  2.665 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  4.710 s
[INFO] Finished at: 2023-01-13T16:10:57+01:00
[INFO] ------------------------------------------------------------------------


$ ls -al ~/.m2/repository/org/apache/flink/flink-connector-jdbc/3.1-SNAPSHOT
drwxr-xr-x@ 9 zsomborchikan  staff     288 Jan 13 16:10 .
drwxr-xr-x@ 6 zsomborchikan  staff     192 Jan 13 15:31 ..
-rw-r--r--@ 1 zsomborchikan  staff     367 Jan 13 16:10 _remote.repositories
-rw-r--r--@ 1 zsomborchikan  staff  121924 Jan 13 16:10 flink-connector-jdbc-3.1-SNAPSHOT-cyclonedx.json
-rw-r--r--@ 1 zsomborchikan  staff  104582 Jan 13 16:10 flink-connector-jdbc-3.1-SNAPSHOT-cyclonedx.xml
-rw-r--r--@ 1 zsomborchikan  staff  269933 Jan 13 16:10 flink-connector-jdbc-3.1-SNAPSHOT-tests.jar
-rw-r--r--@ 1 zsomborchikan  staff  265737 Jan 13 16:10 flink-connector-jdbc-3.1-SNAPSHOT.jar
-rw-r--r--@ 1 zsomborchikan  staff   13143 Jan 13 16:10 flink-connector-jdbc-3.1-SNAPSHOT.pom
-rw-r--r--@ 1 zsomborchikan  staff    1328 Jan 13 16:10 maven-metadata-local.xml
```

## Does this pull request potentially affect one of the following parts:
- Dependencies (does it add or upgrade a dependency): Yes, but it's plugin dependency.
- The public API, i.e., is any changed class annotated with @Public(Evolving): No
- The serializers: No
- The runtime per-record code paths (performance sensitive): No
- Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn, ZooKeeper: No
- The S3 file system connector: No

## Documentation
- Does this pull request introduce a new feature? No
- If yes, how is the feature documented? N/A