### PR TITLE
[FLINK-31475] Allow project to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Updates the version in the poms of the current branch to `${NEW_VERSION}`.
 
 Creates a source release from the current branch and pushes it via `svn`
 to [dist.apache.org](https://dist.apache.org/repos/dist/dev/flink).  
+The project name is automatically determined from the repository name, but can be overridden via `${PROJECT}`.
 The version is automatically determined from the version in the pom.  
 The created `svn` directory will contain a `-rc${RC_NUM}` suffix.
 

--- a/stage_source_release.sh
+++ b/stage_source_release.sh
@@ -33,7 +33,7 @@ function create_source_release {
   mkdir -p ${RELEASE_DIR}
   mkdir -p ${ARTIFACTS_DIR}
 
-  project=${PWD##*/}
+  project=${PROJECT:-PWD##*/}
   version=$(get_pom_version)
   if [[ ${version} =~ -SNAPSHOT$ ]]; then
     echo "Source releases should not be created for SNAPSHOT versions. Use 'update_branch_version.sh' first."
@@ -57,7 +57,7 @@ function create_source_release {
 
 function deploy_source_release {
   cd ${SOURCE_DIR}
-  project=${PWD##*/}
+  project=${PROJECT:-PWD##*/}
   version=$(get_pom_version)-rc${RC_NUM}
 
   release=${project}-${version}


### PR DESCRIPTION
Small change to allow the project to be set by the user.

I needed this for the connector-parent release, because the automatically inferred name was `flink-connector-shared-utils`.