### PR TITLE
[FLINK-31923][Build System] Enable checking out specific branches for shared workflow.

### DIFF
--- a/.github/workflows/_testing.yml
+++ b/.github/workflows/_testing.yml
@@ -26,12 +26,32 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       flink_version: 1.16.1
+      connector_branch: ci_utils
   snapshot-version:
     uses: ./.github/workflows/ci.yml
     with:
       flink_version: 1.16-SNAPSHOT
+      connector_branch: ci_utils
   disable-convergence:
     uses: ./.github/workflows/ci.yml
     with:
       flink_version: 1.16.1
+      connector_branch: ci_utils
       run_dependency_convergence: false
+  multiple-branches:
+    strategy:
+      matrix:
+        flink_branches: [{
+          flink: 1.16.1,
+          branch: ci_utils
+        }, {
+          flink: 1.17.1,
+          branch: ci_utils
+        }, {
+          flink: 1.16.1,
+          branch: test_project
+        }]
+    uses: ./.github/workflows/ci.yml
+    with:
+      flink_version: ${{ matrix.flink_branches.flink }}
+      connector_branch: ${{ matrix.flink_branches.branch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,11 @@ on:
         required: false
         type: boolean
         default: true
+      connector_branch:
+        description: "Branch that need to be checked out"
+        required: false
+        type: string
+        default: main
 
 jobs:
   compile_and_test:
@@ -65,6 +70,8 @@ jobs:
 
       - name: Check out repository code
         uses: actions/checkout@v3
+        with:
+          ref: "${{ inputs.connector_branch }}"
 
       - name: Set JDK
         uses: actions/setup-java@v3


### PR DESCRIPTION
This makes it possible to schedule weekly builds, which need to be run on multiple branches. As a default, we always set `main`