### PR TITLE
[FLINK-32448] Remove `main` as default branch for CI runs

### DIFF
--- a/.github/workflows/_testing.yml
+++ b/.github/workflows/_testing.yml
@@ -42,13 +42,15 @@ jobs:
     strategy:
       matrix:
         flink_branches: [{
-          flink: 1.16.1,
-          branch: ci_utils
+          flink: 1.16.1
+#          By not specifying a branch, it should default to the branch that triggers this workflow
         }, {
           flink: 1.17.1,
+#          By specifying this branch, it should check out this specified branch
           branch: ci_utils
         }, {
           flink: 1.16.1,
+#          By specifying a different branch then on L49, it should check out this specified branch
           branch: test_project
         }]
     uses: ./.github/workflows/ci.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,6 @@ on:
         description: "Branch that need to be checked out"
         required: false
         type: string
-        default: main
 
 jobs:
   compile_and_test:


### PR DESCRIPTION
This should result in the situation that:

1. When checking out the repository that triggered a workflow, it defaults to the reference or SHA for that event. Otherwise, uses the default branch.
2. When a connector branch has been specified, it uses that specific reference or SHA