### PR TITLE
[hotifx] Extends the main branch's README.md to have a more informative "landing page".

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-This repository contains utilities for [Apache Flink](https://flink.apache.org/) connectors.
+This repository contains utilities for [Apache Flink](https://flink.apache.org/) connectors. It is organized in branches:
+
+* [ci_utils](https://github.com/apache/flink-connector-shared-utils/tree/ci_utils)
+* [release_utils](https://github.com/apache/flink-connector-shared-utils/tree/release_utils)
+* [parent_pom](https://github.com/apache/flink-connector-shared-utils/tree/parent_pom)
+* [test_project](https://github.com/apache/flink-connector-shared-utils/tree/test_project)
+
+Further details can be found on the branch's `README.md` or in the [documentation on Externalized Connector Development](https://cwiki.apache.org/confluence/display/FLINK/Externalized+Connector+development).


### PR DESCRIPTION
This adds more description to the repo to make newcomers aware that the source is "hidden" in other branches. Additionally, I added the link to the Flink wiki. 