### PR TITLE
[FLINK-29436] Spotless 2.27.1 already supports JDK 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ under the License.
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
-                    <version>2.38.0</version>
+                    <version>2.27.1</version>
                     <configuration>
                         <java>
                             <googleJavaFormat>

--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@ under the License.
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
-                    <version>2.27.1</version>
+                    <version>2.38.0</version>
                     <configuration>
                         <java>
                             <googleJavaFormat>
@@ -908,30 +908,6 @@ under the License.
                 </pluginManagement>
             </build>
         </profile>
-        <profile>
-            <id>java17</id>
-            <activation>
-                <jdk>[17,)</jdk>
-            </activation>
-
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>com.diffplug.spotless</groupId>
-                            <artifactId>spotless-maven-plugin</artifactId>
-                            <configuration>
-                                <!-- Current google format does not run on Java 17.
-                                     Don't upgrade it in this profile because it formats code differently.
-                                     Re-evaluate once support for Java 8 is dropped. -->
-                                <skip>true</skip>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-
         <profile>
             <id>java11-target</id>
             <build>


### PR DESCRIPTION
This is a subtask of FLINK-29436.

I'm using JDK17 and I found this task skipped when developing the pulsar connector.

Since the block is already fixed at https://github.com/apache/flink/pull/20911, we can do the same here and release a 1.0.1 or 1.1.0.

cc @zentol 