### PR TITLE
[FLINK-32894] Use 3.5.1 for maven-shade-plugin to support Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,7 +437,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.5.1</version>
                     <configuration>
                         <!-- This section contains the core configuration that is applied to every jar that we create.-->
                         <filters combine.children="append">
@@ -878,11 +878,6 @@ under the License.
                 <pluginManagement>
                     <plugins>
                         <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-shade-plugin</artifactId>
-                            <version>3.2.4</version>
-                        </plugin>
-                        <plugin>
                             <groupId>io.github.zentol.japicmp</groupId>
                             <artifactId>japicmp-maven-plugin</artifactId>
                             <dependencies>
@@ -916,23 +911,6 @@ under the License.
                                     <additionalJOption>--add-exports=java.base/sun.net.util=ALL-UNNAMED</additionalJOption>
                                 </additionalJOptions>
                             </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
-            <id>java17</id>
-            <activation>
-                <jdk>[17,)</jdk>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-shade-plugin</artifactId>
-                            <version>3.3.0</version>
                         </plugin>
                     </plugins>
                 </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -922,6 +922,23 @@ under the License.
             </build>
         </profile>
         <profile>
+            <id>java17</id>
+            <activation>
+                <jdk>[17,)</jdk>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-shade-plugin</artifactId>
+                            <version>3.3.0</version>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
             <id>java11-target</id>
             <build>
                 <plugins>


### PR DESCRIPTION
This pull requests add profile `java17` and pin `maven-shade-plugin`'s version to 3.3.0 in order to make shading work under Java 17. 