### PR TITLE
[FLINK-32563] Add disable-archunit-tests profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ under the License.
 
     <groupId>org.apache.flink</groupId>
     <artifactId>flink-connector-parent</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>pom</packaging>
 
     <url>https://flink.apache.org</url>
@@ -793,6 +793,28 @@ under the License.
                                 <phase>${flink.convergence.phase}</phase>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>disable-archunit-tests</id>
+            <activation>
+                <property>
+                    <name>disable-archunit-tests</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>**/*ArchitectureTest.java</exclude>
+                            </excludes>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
This new profile will be used to disable archunit tests in the CI when connectors are tested against non-main Flink version (every version that is not the version they were built against including snapshots). This PR is part of a bigger work on CI (spread accross multiple branches in multiple PRs) to disable all sanity checks (including dependency-convergence) on non-main Flink versions.

R: @MartijnVisser
CC: @tzulitai