### PR TITLE
[FLINK-33302] Allow to customize jdk version for connectors

### DIFF
--- a/.github/workflows/_testing.yml
+++ b/.github/workflows/_testing.yml
@@ -32,9 +32,10 @@ jobs:
     with:
       flink_version: 1.16-SNAPSHOT
       connector_branch: ci_utils
-  snapshot18-version:
+  flink118-java17-version:
     uses: ./.github/workflows/ci.yml
     with:
+#     This should be replaced with 1.18.0 once it is released
       flink_version: 1.18-SNAPSHOT
       jdk_version: 17
       connector_branch: ci_utils

--- a/.github/workflows/_testing.yml
+++ b/.github/workflows/_testing.yml
@@ -49,6 +49,11 @@ jobs:
 #          By specifying this branch, it should check out this specified branch
           branch: ci_utils
         }, {
+#          JAva 17 supported since 1.18, should be replaced with 1.18.0, once it is released
+          flink: 1.18-SNAPSHOT,
+          jdk: 17,
+          branch: ci_utils
+        }, {
           flink: 1.16.1,
 #          By specifying a different branch then on L49, it should check out this specified branch
           branch: test_project
@@ -57,3 +62,4 @@ jobs:
     with:
       flink_version: ${{ matrix.flink_branches.flink }}
       connector_branch: ${{ matrix.flink_branches.branch }}
+      jdk_version: ${{ matrix.flink_branches.jdk }}

--- a/.github/workflows/_testing.yml
+++ b/.github/workflows/_testing.yml
@@ -35,8 +35,7 @@ jobs:
   flink118-java17-version:
     uses: ./.github/workflows/ci.yml
     with:
-#     This should be replaced with 1.18.0 once it is released
-      flink_version: 1.18-SNAPSHOT
+      flink_version: 1.18.0
       jdk_version: 17
       connector_branch: ci_utils
       run_dependency_convergence: false

--- a/.github/workflows/_testing.yml
+++ b/.github/workflows/_testing.yml
@@ -32,6 +32,12 @@ jobs:
     with:
       flink_version: 1.16-SNAPSHOT
       connector_branch: ci_utils
+  snapshot18-version:
+    uses: ./.github/workflows/ci.yml
+    with:
+      flink_version: 1.18-SNAPSHOT
+      jdk_version: 17
+      connector_branch: ci_utils
   disable-convergence:
     uses: ./.github/workflows/ci.yml
     with:
@@ -47,11 +53,6 @@ jobs:
         }, {
           flink: 1.17.1,
 #          By specifying this branch, it should check out this specified branch
-          branch: ci_utils
-        }, {
-#          JAva 17 supported since 1.18, should be replaced with 1.18.0, once it is released
-          flink: 1.18-SNAPSHOT,
-          jdk: 17,
           branch: ci_utils
         }, {
           flink: 1.16.1,

--- a/.github/workflows/_testing.yml
+++ b/.github/workflows/_testing.yml
@@ -39,6 +39,7 @@ jobs:
       flink_version: 1.18-SNAPSHOT
       jdk_version: 17
       connector_branch: ci_utils
+      run_dependency_convergence: false
   disable-convergence:
     uses: ./.github/workflows/ci.yml
     with:
@@ -64,4 +65,3 @@ jobs:
     with:
       flink_version: ${{ matrix.flink_branches.flink }}
       connector_branch: ${{ matrix.flink_branches.branch }}
-      jdk_version: ${{ matrix.flink_branches.jdk }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ on:
         description: "Flink version to test against."
         required: true
         type: string
+      jdk_version:
+        description: "Jdk version to test against."
+        required: false
+        default: 8, 11
+        type: string
       cache_flink_binary:
         description: "Whether to cache the Flink binary. If not set this parameter is inferred from the version parameter. Must be set if 'flink_url' is used."
         required: false
@@ -56,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        jdk: [8, 11]
+        jdk: ${{ fromJSON(format('[{0}]', inputs.jdk_version)) }}
     timeout-minutes: ${{ inputs.timeout_global }}
     env:
       MVN_COMMON_OPTIONS: -U -B --no-transfer-progress -Dflink.version=${{ inputs.flink_version }}

--- a/pom.xml
+++ b/pom.xml
@@ -43,19 +43,21 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-core</artifactId>
 			<version>${flink.version}</version>
+			<!--
+			Exclude since from testcontainers it comes newer (1.23.0) version
+			-->
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-compress</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils-junit</artifactId>
 			<version>${flink.version}</version>
 			<scope>test</scope>
-		</dependency>
-
-		<!-- For dependency convergence -->
-		<dependency>
-			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-compress</artifactId>
-			<version>${commons-compress.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
+		<commons-compress.version>1.23.0</commons-compress.version>
 		<flink.version>1.16.1</flink.version>
 		<japicmp.referenceVersion>1.16.0</japicmp.referenceVersion>
 	</properties>
@@ -48,6 +49,13 @@ under the License.
 			<artifactId>flink-test-utils-junit</artifactId>
 			<version>${flink.version}</version>
 			<scope>test</scope>
+		</dependency>
+
+		<!-- For dependency convergence -->
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-compress</artifactId>
+			<version>${commons-compress.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,8 +33,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<commons-compress.version>1.23.0</commons-compress.version>
-		<flink.version>1.16.1</flink.version>
+		<flink.version>1.18-SNAPSHOT</flink.version>
 		<japicmp.referenceVersion>1.16.0</japicmp.referenceVersion>
 	</properties>
 
@@ -43,21 +42,18 @@ under the License.
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-core</artifactId>
 			<version>${flink.version}</version>
-			<!--
-			Exclude since from testcontainers it comes newer (1.23.0) version
-			-->
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.commons</groupId>
-					<artifactId>commons-compress</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-test-utils-junit</artifactId>
 			<version>${flink.version}</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.apache.commons</groupId>
+					<artifactId>commons-compress</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@ under the License.
 	<packaging>jar</packaging>
 
 	<properties>
-		<flink.version>1.18-SNAPSHOT</flink.version>
+		<flink.version>1.16.1</flink.version>
 		<japicmp.referenceVersion>1.16.0</japicmp.referenceVersion>
 	</properties>
 
@@ -48,12 +48,6 @@ under the License.
 			<artifactId>flink-test-utils-junit</artifactId>
 			<version>${flink.version}</version>
 			<scope>test</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>org.apache.commons</groupId>
-					<artifactId>commons-compress</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
The PR allows to customize jdk versions
At the same time it still keeps 8 and 1 as default fullback option

An example of connector with this 
https://github.com/snuyanzin/flink-connector-opensearch/actions/runs/6560306886/job/17817647898
where 1.16.x, 1.17.x are running with 8 and 11 and 1.18.x with 8, 11, 17

the failure of the connector is related to connector's code which still doesn't support jdk17