### PR TITLE
[FLINK-32563] add additionalExcludes property to add exclusions to surefire tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ under the License.
 
     <groupId>org.apache.flink</groupId>
     <artifactId>flink-connector-parent</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>pom</packaging>
 
     <url>https://flink.apache.org</url>
@@ -80,6 +80,10 @@ under the License.
         <japicmp.referenceVersion/>
         <flink.version/>
         <flink.parent.artifactId/>
+
+        <!-- optional property to add exclusions to surefire tests
+        (among other things for skipping archunit tests) -->
+        <additionalExcludes/>
     </properties>
 
     <build>
@@ -570,6 +574,9 @@ under the License.
                                 <includes>
                                     <include>${test.unit.pattern}</include>
                                 </includes>
+                                <excludes>
+                                    <exclude>${additionalExcludes}</exclude>
+                                </excludes>
                                 <forkCount>${flink.forkCountUnitTest}</forkCount>
                                 <argLine>${flink.surefire.baseArgLine} -Xmx${flink.XmxUnitTest}</argLine>
                             </configuration>
@@ -587,6 +594,7 @@ under the License.
                                 </includes>
                                 <excludes>
                                     <exclude>${test.unit.pattern}</exclude>
+                                    <exclude>${additionalExcludes}</exclude>
                                 </excludes>
                                 <forkCount>${flink.forkCountITCase}</forkCount>
                                 <argLine>${flink.surefire.baseArgLine} -Xmx${flink.XmxITCase}</argLine>


### PR DESCRIPTION
Related to what was discussed [here](https://github.com/apache/flink-connector-shared-utils/pull/23#discussion_r1383402031), this PR adds an optional property to add exclusions to surefire tests (among other things for skipping archunit tests).

This also increments the minor version of org.apache.flink:flink-connector-parent and requires releasing flink-connector-parent to use in ci_utils branch.

As discussed, I have tested the integration with ci_utils [there](https://github.com/echauchot/flink-connector-shared-utils-test/actions/runs/6852330552/job/18630619522) using: 
- a flink-connector-shared-utils-**test** clone repo and a **io.github.echauchot.flink**:flink-connector-parent custom artifact to be able to directly commit and install the artifact in the CI
- a custom ci script that does the cloning and mvn install in the ci.yml github action script for testing
 
R: @zentol