### PR TITLE
[FLINK-33776] Allow to specify optional profile for connectors

### DIFF
--- a/.github/workflows/_testing.yml
+++ b/.github/workflows/_testing.yml
@@ -50,7 +50,8 @@ jobs:
     with:
       flink_version: 1.16-SNAPSHOT
       connector_branch: ci_utils
-      optional_maven_profiles: java11
+      jdk_version: 11
+      optional_maven_profiles: "java11,java11-target"
   multiple-branches:
     strategy:
       matrix:

--- a/.github/workflows/_testing.yml
+++ b/.github/workflows/_testing.yml
@@ -45,6 +45,12 @@ jobs:
       flink_version: 1.16.1
       connector_branch: ci_utils
       run_dependency_convergence: false
+  optional_maven_profile:
+    uses: ./.github/workflows/ci.yml
+    with:
+      flink_version: 1.16-SNAPSHOT
+      connector_branch: ci_utils
+      optional_maven_profiles: "java11,java11-target"
   multiple-branches:
     strategy:
       matrix:

--- a/.github/workflows/_testing.yml
+++ b/.github/workflows/_testing.yml
@@ -50,7 +50,7 @@ jobs:
     with:
       flink_version: 1.16-SNAPSHOT
       connector_branch: ci_utils
-      optional_maven_profiles: "java11,java11-target"
+      optional_maven_profiles: java11
   multiple-branches:
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,6 @@ on:
         type: string
       optional_maven_profiles:
         description: "Optional maven profiles."
-        default: non_existing_profile
         required: false
         type: string
 
@@ -69,7 +68,7 @@ jobs:
         jdk: ${{ fromJSON(format('[{0}]', inputs.jdk_version)) }}
     timeout-minutes: ${{ inputs.timeout_global }}
     env:
-      MVN_COMMON_OPTIONS: -U -B --no-transfer-progress -Dflink.version=${{ inputs.flink_version }} -P ${{ inputs.optional_maven_profiles }}
+      MVN_COMMON_OPTIONS: -U -B --no-transfer-progress -Dflink.version=${{ inputs.flink_version }}
       MVN_CONNECTION_OPTIONS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       FLINK_CACHE_DIR: "/tmp/cache/flink"
       MVN_BUILD_OUTPUT_FILE: "/tmp/mvn_build_output.out"
@@ -97,6 +96,10 @@ jobs:
       - name: "Enable dependency convergence check"
         if: ${{ inputs.run_dependency_convergence }}
         run: echo "MVN_DEPENDENCY_CONVERGENCE=-Dflink.convergence.phase=install -Pcheck-convergence" >> $GITHUB_ENV
+
+      - name: "Enable optional maven profiles"
+        if: ${{ inputs.optional_maven_profiles }}
+        run: echo "MVN_COMMON_OPTIONS=${MVN_COMMON_OPTIONS} -P ${{ inputs.optional_maven_profiles }}" >> $GITHUB_ENV
 
       - name: "Determine Flink binary url"
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,11 @@ on:
         description: "Branch that need to be checked out"
         required: false
         type: string
+      optional_maven_profiles:
+        description: "Optional maven profiles."
+        default: non_existing_profile
+        required: false
+        type: string
 
 jobs:
   compile_and_test:
@@ -64,7 +69,7 @@ jobs:
         jdk: ${{ fromJSON(format('[{0}]', inputs.jdk_version)) }}
     timeout-minutes: ${{ inputs.timeout_global }}
     env:
-      MVN_COMMON_OPTIONS: -U -B --no-transfer-progress -Dflink.version=${{ inputs.flink_version }}
+      MVN_COMMON_OPTIONS: -U -B --no-transfer-progress -Dflink.version=${{ inputs.flink_version }} -P ${{ inputs.optional_maven_profiles }}
       MVN_CONNECTION_OPTIONS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       FLINK_CACHE_DIR: "/tmp/cache/flink"
       MVN_BUILD_OUTPUT_FILE: "/tmp/mvn_build_output.out"


### PR DESCRIPTION


The issue is that sometimes the connector should be tested against several versions of sinks/sources

e.g. hive connector should be tested against hive 2 and hive3, opensearch should be tested against 1 and 2
one of the way is using profiles for that

this PR adds ability to specify profiles