### PR TITLE
[FLINK-33796] Add ability to customize java version for python ci in connectors

### DIFF
--- a/.github/workflows/_testing.yml
+++ b/.github/workflows/_testing.yml
@@ -71,3 +71,17 @@ jobs:
     with:
       flink_version: ${{ matrix.flink_branches.flink }}
       connector_branch: ${{ matrix.flink_branches.branch }}
+
+  specific-version-python:
+    uses: ./.github/workflows/python_ci.yml
+    with:
+      flink_version: 1.16.1
+  snapshot-version-python:
+    uses: ./.github/workflows/python_ci.yml
+    with:
+      flink_version: 1.16-SNAPSHOT
+  flink118-java17-version-python:
+    uses: ./.github/workflows/python_ci.yml
+    with:
+      flink_version: 1.18.0
+      jdk_version: 17

--- a/.github/workflows/_testing.yml
+++ b/.github/workflows/_testing.yml
@@ -71,17 +71,3 @@ jobs:
     with:
       flink_version: ${{ matrix.flink_branches.flink }}
       connector_branch: ${{ matrix.flink_branches.branch }}
-
-  specific-version-python:
-    uses: ./.github/workflows/python_ci.yml
-    with:
-      flink_version: 1.16.1
-  snapshot-version-python:
-    uses: ./.github/workflows/python_ci.yml
-    with:
-      flink_version: 1.16-SNAPSHOT
-  flink118-java17-version-python:
-    uses: ./.github/workflows/python_ci.yml
-    with:
-      flink_version: 1.18.0
-      jdk_version: 17

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -23,6 +23,11 @@ on:
         description: "Flink version to test against."
         required: true
         type: string
+      jdk_version:
+        description: "Jdk version to test against."
+        required: false
+        default: 8, 11
+        type: string
       timeout_global:
         description: "The timeout in minutes for the entire workflow."
         required: false
@@ -41,6 +46,9 @@ on:
 jobs:
   python_test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jdk: ${{ fromJSON(format('[{0}]', inputs.jdk_version)) }}
     timeout-minutes: ${{ inputs.timeout_global }}
     env:
       MVN_COMMON_OPTIONS: -U -B --no-transfer-progress -Dflink.version=${{ inputs.flink_version }} -DskipTests
@@ -57,7 +65,7 @@ jobs:
       - name: Set JDK
         uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
           cache: 'maven'
 

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -26,7 +26,7 @@ on:
       jdk_version:
         description: "Jdk version to test against."
         required: false
-        default: 8, 11
+        default: 8
         type: string
       timeout_global:
         description: "The timeout in minutes for the entire workflow."


### PR DESCRIPTION
Besides adding ability to customize java version ~~it also adds some tests for it~~ (currently without tests since python scripts expects `flink-python` folder and other acripts available)
The PR is done in a similar way it is done for non-python ci