### PR TITLE
[hotfix] Set version to 1.1.0 and not 1.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ under the License.
 
     <groupId>org.apache.flink</groupId>
     <artifactId>flink-connector-parent</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
     <packaging>pom</packaging>
 
     <url>https://flink.apache.org</url>


### PR DESCRIPTION
@zentol next version jira label for new connector-parent already exists but contains version 1.1.0 and not 1.0.1 (hence this change). Do you agree that the yet-to-release changes [1] are worth incrementing the minor version instead of the patch version?
[1]: 
https://github.com/apache/flink-connector-shared-utils/commit/813ab45461ef29dd841d63995e97b40125a0d7e4
https://github.com/apache/flink-connector-shared-utils/commit/808184ab723d678a4966ae4c45096c4bd6d3e756
https://github.com/apache/flink-connector-shared-utils/commit/ac09d18d874691f00629c90726458011034ea106
https://github.com/apache/flink-connector-shared-utils/commit/7c2745af777c6681b9eb14f0b05b2136fb141784

CC: @snuyanzin