### PR TITLE
[FLINK-34267][CI] Update miniconda install script to fix build on MacOS

### DIFF
--- a/python/lint-python.sh
+++ b/python/lint-python.sh
@@ -185,8 +185,8 @@ function install_wget() {
 # some packages including checks such as tox and flake8.
 
 function install_miniconda() {
-    OS_TO_CONDA_URL=("https://repo.continuum.io/miniconda/Miniconda3-4.7.10-MacOSX-x86_64.sh" \
-        "https://repo.continuum.io/miniconda/Miniconda3-4.7.10-Linux-x86_64.sh")
+    OS_TO_CONDA_URL=("https://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-MacOSX-x86_64.sh" \
+        "https://repo.continuum.io/miniconda/Miniconda3-4.7.12.1-Linux-x86_64.sh")
     if [ ! -f "$CONDA_INSTALL" ]; then
         print_function "STEP" "download miniconda..."
         download ${OS_TO_CONDA_URL[$1]} $CONDA_INSTALL_SH


### PR DESCRIPTION
Fix miniconda environment install on MacOS.
Change has been tested on MacOS 14.2.1 and Amazon Linux 2.