### PR TITLE
[FLINK-34314] Update CI Node Actions from NodeJS 16 to NodeJS 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,12 @@ jobs:
       - run: echo "Running CI pipeline for JDK version ${{ matrix.jdk }}"
 
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: "${{ inputs.connector_branch }}"
 
       - name: Set JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
@@ -117,7 +117,7 @@ jobs:
 
       - name: Restore cached Flink binary
         if: ${{ env.cache_binary == 'true' }}
-        uses: actions/cache/restore@v3
+        uses: actions/cache/restore@v4
         id: restore-cache-flink
         with:
           path: ${{ env.FLINK_CACHE_DIR }}
@@ -130,7 +130,7 @@ jobs:
 
       - name: Cache Flink binary
         if: ${{ env.cache_binary == 'true' }}
-        uses: actions/cache/save@v3
+        uses: actions/cache/save@v4
         id: cache-flink
         with:
           path: ${{ env.FLINK_CACHE_DIR }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
           cache: 'maven'
 
       - name: Set Maven 3.8.6
-        uses: stCarolas/setup-maven@v4.5
+        uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.8.6
 


### PR DESCRIPTION
There's no update yet for stCarolas/setup-maven. There is an open PR for it at https://github.com/stCarolas/setup-maven/pull/36 

Let's wait with merging this one until there's an update for that Github Action as well