### PR TITLE
[hotfix] Exclude whole tools directory instead of tools/releasing/shared from source release

### DIFF
--- a/_utils.sh
+++ b/_utils.sh
@@ -49,7 +49,8 @@ function create_pristine_source {
     --exclude ".idea" --exclude "*.iml" \
     --exclude ".DS_Store" \
     --exclude ".asf.yaml" \
-    --exclude "target" --exclude "tools/releasing/shared" \
+    --exclude "target"  \
+    --exclude "tools" \
     "${clone_dir}/" "${clean_dir}"
 
   rm -rf "${clone_dir}"


### PR DESCRIPTION
With this change currently releasing connector-parent source release will be cleaned (no tools directory) and next source releases of connectors will be cleaned as well.

FYI: @zentol @MartijnVisser as discussed in the ML
