### PR TITLE
[FLINK-34363] Set artifact version to $project_version if $FLINK_VERSION is not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ The created `svn` directory will contain a `-rc${RC_NUM}` suffix.
 ## stage_jars.sh
 
 Creates the jars from the current branch and deploys them to [repository.apache.org](https://repository.apache.org).  
-The version will be suffixed with the Flink minor version, extracted from`${FLINK_VERSION}`, to indicate the supported Flink version.  
-If a particular version of a connector supports multiple Flink versions then this script should be called multiple
-times.
+If `${FLINK_VERSION}` is defined, the version will be suffixed with the Flink minor version, extracted from
+`${FLINK_VERSION}` to indicate the supported Flink version. If `${FLINK_VERSION}` is not defined 
+(for example for `flink-connector-parent` releases), the version will be the one extracted from the pom. 
+If a particular version of a connector supports multiple Flink versions then this script should be called multiple times.
 
 ## release_source_release.sh
 

--- a/_utils.sh
+++ b/_utils.sh
@@ -73,7 +73,7 @@ function set_pom_version {
 function is_flink_version_set_in_pom {
   set +u
   version=$(${MVN} help:evaluate -Dexpression="flink.version" -q -DforceStdout)
-  if [ -n "${version}" ]; then
+  if [[ "${version}" =~ ^[0-9\.\-]+$ ]]; then
       echo "true"
     else
       echo "false"

--- a/_utils.sh
+++ b/_utils.sh
@@ -69,3 +69,14 @@ function set_pom_version {
 
   ${MVN} org.codehaus.mojo:versions-maven-plugin:2.8.1:set -DnewVersion=${new_version} -DgenerateBackupPoms=false --quiet
 }
+
+function is_flink_version_set_in_pom {
+  set +u
+  version=$(${MVN} help:evaluate -Dexpression="flink.version" -q -DforceStdout)
+  if [ -n "${version}" ]; then
+      echo "true"
+    else
+      echo "false"
+  fi
+  set -u
+}

--- a/stage_jars.sh
+++ b/stage_jars.sh
@@ -24,10 +24,6 @@ source "${SCRIPT_DIR}/_utils.sh"
 
 ###########################
 
-check_variables_set FLINK_VERSION
-
-###########################
-
 function deploy_staging_jars {
   cd "${SOURCE_DIR}"
   mkdir -p "${RELEASE_DIR}"
@@ -37,8 +33,14 @@ function deploy_staging_jars {
     echo "Jars should not be created for SNAPSHOT versions. Use 'update_branch_version.sh' first."
     exit 1
   fi
-  flink_minor_version=$(echo ${FLINK_VERSION} | sed "s/.[0-9]\+$//")
-  version=${project_version}-${flink_minor_version}
+
+  if [ "$(is_flink_version_set_in_pom)" == "true" ]; then # it is a regular connector release
+    check_variables_set FLINK_VERSION
+    flink_minor_version=$(echo ${FLINK_VERSION} | sed "s/.[0-9]\+$//")
+    version="${project_version}-${flink_minor_version}"
+  else # it is a connector-parent release
+    version="${project_version}"
+  fi
 
   echo "Deploying jars v${version} to repository.apache.org"
   echo "To revert this step, login to 'https://repository.apache.org' -> 'Staging repositories' -> Select repository -> 'Drop'"


### PR DESCRIPTION
[FLINK-34363](https://issues.apache.org/jira/browse/FLINK-34363)

This script change is needed for flink-connector-parent releases and it was tested as following:
- **with $FLINK_VERSION not set**:  to build flink-connector-parent-1.1.0-rc2 
- **with $FLINK_VERSION set**: to build a local release of flink-connector-cassandra

Also, after the merge, I'll update the wiki [connector release page](https://cwiki.apache.org/confluence/display/FLINK/Creating+a+flink-connector+release) to indicate flink-connector-parent release specificities (need to override $PROJECT and need to specify no  $FLINK_VERSION) 