### PR TITLE
[FLINK-35124] Include Maven build configuration in the pristine source clone

### DIFF
--- a/_utils.sh
+++ b/_utils.sh
@@ -50,7 +50,7 @@ function create_pristine_source {
     --exclude ".DS_Store" \
     --exclude ".asf.yaml" \
     --exclude "target"  \
-    --exclude "tools" \
+    --exclude "tools/releasing/shared" \
     "${clone_dir}/" "${clean_dir}"
 
   rm -rf "${clone_dir}"


### PR DESCRIPTION
Reverting https://github.com/apache/flink-connector-shared-utils/commit/a75b89ee3f8c9a03e97ead2d0bd9d5b7bb02b51a to ensure Maven build configuration is included in the source archive 