### PR TITLE
[hotfix] Make cutting patch version in stage_jars.sh platform-agnostic

### DIFF
--- a/stage_jars.sh
+++ b/stage_jars.sh
@@ -36,7 +36,7 @@ function deploy_staging_jars {
 
   if [ "$(is_flink_version_set_in_pom)" == "true" ]; then # it is a regular connector release
     check_variables_set FLINK_VERSION
-    flink_minor_version=${FLINK_MINOR_VERSION:-$(echo ${FLINK_VERSION} | sed "s/.[0-9]\+$//")}
+    flink_minor_version=${FLINK_MINOR_VERSION:-$(echo ${FLINK_VERSION} | cut -d '.' -f 1,2)}
     version="${project_version}-${flink_minor_version}"
   else # it is a connector-parent release
     version="${project_version}"


### PR DESCRIPTION
The previous `sed` command does not cut the patch version on MacOS:
```sh
~/dev/flink-connector-shared-utils on fix-patch-version-cut-on-mac
% sw_vers
ProductName:		macOS
ProductVersion:		14.7
BuildVersion:		23H124

~/dev/flink-connector-shared-utils on fix-patch-version-cut-on-mac
% FLINK_VERSION=1.19.1; echo ${FLINK_VERSION} | sed "s/.[0-9]\+$//"
1.19.1
```
`cut` works the same on Linux and Mac as well:
```sh
% FLINK_VERSION=1.19.1; echo ${FLINK_VERSION} | cut -d '.' -f 1,2
1.19
```