### PR TITLE
Adding support for TARGET_VERSION, automatically detect mvnw, and warn about mac sed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ under `tools/releasing/shared`.
 # Usage
 
 Some scripts rely on environment variables to be set.  
+```
+export NEW_VERSION=3.0.0
+export TARGET_JAVA_VERSION=8
+export RC_NUM=1
+export PROJECT=flink-connector-<project>
+export REMOTE=origin
+export MAVEN_SKIP_RC=false
+export MAVEN_OPTS=""
+export MAVEN_CONFIG=""
+export MAVEN_DEBUG_OPTS=""
+```
 These are checked at the start of each script.  
 Any instance of `${some_variable}` in this document refers to an environment variable that is used by the respective
 script.

--- a/_init.sh
+++ b/_init.sh
@@ -28,7 +28,7 @@ export SHELLOPTS
 
 ###########################
 
-MVN=${MVN:-mvn}
+TARGET_JAVA_VERSION=${TARGET_JAVA_VERSION:-8}
 
 if [ "$(uname)" == "Darwin" ]; then
     SHASUM="shasum -a 512"
@@ -46,3 +46,11 @@ ARTIFACTS_DIR=${SOURCE_DIR}/tools/releasing/release/artifacts
 
 SVN_DEV_DIR="https://dist.apache.org/repos/dist/dev/flink"
 SVN_RELEASE_DIR="https://dist.apache.org/repos/dist/release/flink"
+
+if [ -n "MVN" ]; then
+  if [ -e "${SOURCE_DIR}/mvnw" ]; then
+    MVN=${SOURCE_DIR}/mvnw
+  else
+    MVN=mvn
+  fi
+fi

--- a/check_environment.sh
+++ b/check_environment.sh
@@ -24,7 +24,7 @@ source "${SCRIPT_DIR}/_init.sh"
 EXIT_CODE=0
 
 function check_program_available {
-  if program=$(command -v ${1}); then
+  if program=$(command -v ${2:-${1}}); then
     printf "\t%-10s%s\n" "${1}" "using ${program}"
   else
     printf "\t%-10s%s\n" "${1}" "is not available."
@@ -40,8 +40,15 @@ check_program_available gpg
 check_program_available perl
 check_program_available sed
 check_program_available svn
-check_program_available ${MVN}
-check_program_available ${SHASUM}
+check_program_available "\${MVN}" ${MVN}
+check_program_available "\${SHASUM}" ${SHASUM}
+
+if ! (sed --version 2>/dev/null | grep -q "GNU"); then
+  echo "Warning: You are not using GNU sed. Some scripts may not work. If you are using Mac, install gnu-sed (brew install gnu-sed) and make sure that sed points to it (alias sed=\"gsed\")."
+fi
+
+echo -e "\nMaven/Java version:"
+${MVN} --version
 
 function check_git_connectivity {
   cd "${SOURCE_DIR}"
@@ -54,7 +61,7 @@ function check_git_connectivity {
   fi
 }
 
-echo "Checking git remote availability:"
+echo -e "\nChecking git remote availability:"
 if ! (check_git_connectivity); then
   EXIT_CODE=1
 fi

--- a/stage_jars.sh
+++ b/stage_jars.sh
@@ -51,7 +51,7 @@ function deploy_staging_jars {
 
   options="-Prelease,docs-and-source -DskipTests -DretryFailedDeploymentCount=10"
   set +u
-  ${MVN} clean deploy ${options} -Dflink.version=${FLINK_VERSION}
+  ${MVN} clean deploy ${options} -Dflink.version=${FLINK_VERSION} -Dtarget.java.version=${TARGET_JAVA_VERSION}
   set -u
 
   cd "${RELEASE_DIR}"


### PR DESCRIPTION
Complete output of `check_environment.sh`

```
Checking program availability:
        git       using /usr/bin/git
        tar       using /usr/bin/tar
        rsync     using /usr/bin/rsync
        gpg       using /opt/homebrew/bin/gpg
        perl      using /usr/bin/perl
        sed       using /usr/bin/sed
        svn       using /opt/homebrew/bin/svn
        ${MVN}    using /Users/arv/flink-connector-kafka/mvnw
        ${SHASUM} using /usr/bin/shasum
Warning: You are not using GNU sed. Some scripts may not work. If you are using Mac, install gnu-sed (brew install gnu-sed) and make sure that sed points to it (alias sed="gsed").

Maven/Java version:
Apache Maven 3.8.6 (84538c9988a25aec085021c365c560670ad80f63)
Maven home: /Users/arv/.m2/wrapper/dists/apache-maven-3.8.6/fa5e371
Java version: 11.0.23, vendor: Eclipse Adoptium, runtime: /Library/Java/JavaVirtualMachines/temurin-11.jdk/Contents/Home
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "15.4", arch: "aarch64", family: "mac"

Checking git remote availability:
        Using git remote 'upstream'.
All set! :)
```