### PR TITLE
[FLINK-36181] Upgrade java version to 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
       MVN_COMMON_OPTIONS: -U -B --no-transfer-progress
     strategy:
       matrix:
-        java: [8, 11]
+        java: [11, 17]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'

--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@ under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <target.java.version>1.8</target.java.version>
+        <target.java.version>1.11</target.java.version>
         <maven.compiler.source>${target.java.version}</maven.compiler.source>
         <maven.compiler.target>${target.java.version}</maven.compiler.target>
 
@@ -717,7 +717,7 @@ under the License.
                 </property>
             </activation>
             <properties>
-                <target.java.version>1.8</target.java.version>
+                <target.java.version>1.11</target.java.version>
             </properties>
             <build>
                 <plugins>
@@ -751,7 +751,7 @@ under the License.
                                             <version>[3.2.5,)</version>
                                         </requireMavenVersion>
                                         <requireJavaVersion>
-                                            <version>1.8.0</version>
+                                            <version>1.11.0</version>
                                         </requireJavaVersion>
                                     </rules>
                                 </configuration>


### PR DESCRIPTION
As part of https://issues.apache.org/jira/browse/FLINK-36181, we need to upgrade connector parent target java version to 11 to unblock each connectors to be able to upgrade to 11 as well.

This PR also includes another hotfix to upgrade `actions/checkout` and `actions/setup-java` from v2 to v3