### PR TITLE
Make flink download caching conditional on a cache miss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
         run: wget -q -c ${{ env.binary_url }} -O - | tar -xz
 
       - name: Cache Flink binary
-        if: ${{ env.cache_binary == 'true' }}
+        if: steps.restore-cache-flink.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         id: cache-flink
         with:


### PR DESCRIPTION
Currently the Java CI GH Action workflow will try to save the Flink distribution download to the cache, even if it was successfully retrieved in the earlier cache fetch step. 

This is harmless, but leads to warnings in the UI and would be better if it was skipped.