### PR TITLE
Fix Java setup in Python CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ on:
       jdk_version:
         description: "Jdk version to test against."
         required: false
-        default: 8, 11
+        default: 11
         type: string
       cache_flink_binary:
         description: "Whether to cache the Flink binary. If not set this parameter is inferred from the version parameter. Must be set if 'flink_url' is used."
@@ -91,7 +91,7 @@ jobs:
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
-          cache: 'maven'
+          cache: maven
 
       - name: Read maven version
         if: ${{ hashFiles('.mvn/wrapper/maven-wrapper.properties') != '' }}

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -26,7 +26,7 @@ on:
       jdk_version:
         description: "Jdk version to test against."
         required: false
-        default: 8
+        default: 11
         type: string
       timeout_global:
         description: "The timeout in minutes for the entire workflow."
@@ -58,16 +58,16 @@ jobs:
       - run: echo "Running CI pipeline for JDK version ${{ matrix.jdk }}"
 
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: "${{ inputs.connector_branch }}"
 
       - name: Set JDK
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: ${{ matrix.jdk }}
           distribution: 'temurin'
-          cache: 'maven'
+          cache: maven
 
       - name: Set Maven 3.8.6
         uses: stCarolas/setup-maven@v4.5
@@ -79,7 +79,7 @@ jobs:
         run: |
           set -o pipefail
 
-          mvn clean install ${MVN_COMMON_OPTIONS} \
+          mvn clean install ${{ env.MVN_COMMON_OPTIONS }} \
             ${{ env.MVN_CONNECTION_OPTIONS }} \
             -Dlog4j.configurationFile=file://$(pwd)/tools/ci/log4j.properties \
             | tee ${{ env.MVN_BUILD_OUTPUT_FILE }}


### PR DESCRIPTION
The CI in the Flink-Connector-Kafka repository has not passed for over 3 weeks. After some investigation it was found that this was due to the compile step of the Python CI workflow (pulled from this repo) was timing out (at the default 50mins). This was due to long dependency download times. Even though maven caching was enabled this didn't seem to be working.

This PR updates the Java setup action in the Python CI workflow to version to `v4` (matching the java workflow). This seems to fix the caching issue and testing in my local fork of the Flink-Kafka-Connector shows a complete Python CI run in 4 mins (rather than timing out at 50).

This PR also updates the default Java versions, now that Java 8 support has been dropped.