### PR TITLE
[FLINK-38048] Update java version and move parent pom to v2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,19 +24,19 @@ jobs:
       MVN_COMMON_OPTIONS: -U -B --no-transfer-progress
     strategy:
       matrix:
-        java: [8, 11]
+        java: [11, 17]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Set JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java }}
           distribution: 'temurin'
-          cache: 'maven'
+          cache: maven
 
       - name: Set Maven 3.8.6
-        uses: stCarolas/setup-maven@v4.2
+        uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.8.6
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ under the License.
 
     <groupId>org.apache.flink</groupId>
     <artifactId>flink-connector-parent</artifactId>
-    <version>1.1.0</version>
+    <version>2.0.0</version>
     <packaging>pom</packaging>
 
     <url>https://flink.apache.org</url>
@@ -60,9 +60,8 @@ under the License.
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <target.java.version>1.8</target.java.version>
-        <maven.compiler.source>${target.java.version}</maven.compiler.source>
-        <maven.compiler.target>${target.java.version}</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
 
         <test.unit.pattern>**/*Test.*</test.unit.pattern>
         <flink.XmxITCase>2048m</flink.XmxITCase>
@@ -89,6 +88,27 @@ under the License.
         It MUST be a space-separated list not containing any newlines,
         of entries in the form '[-]{2}add-[opens|exports]=<module>/<package>=ALL-UNNAMED'.-->
         <surefire.module.config/>
+
+        <!-- Maven plugin versions -->
+        <apache-rat-plugin.version>0.13</apache-rat-plugin.version>
+        <checkstyle.version>10.18.2</checkstyle.version>
+        <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
+        <directory-maven-plugin.version>0.1</directory-maven-plugin.version>
+        <exec-maven-plugin.version>3.6.2</exec-maven-plugin.version>
+        <google-java-format.version>1.24.0</google-java-format.version>
+        <japicmp-maven-plugin.version>0.18.5</japicmp-maven-plugin.version>
+        <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
+        <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
+        <maven-eclipse-plugin.version>2.8</maven-eclipse-plugin.version>
+        <maven-enforcer-plugin.version>3.1.0</maven-enforcer-plugin.version>
+        <maven-gpg-plugin.version>1.4</maven-gpg-plugin.version>
+        <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
+        <maven-javadoc-plugin.version>3.8.0</maven-javadoc-plugin.version>
+        <maven-release-plugin.version>2.1</maven-release-plugin.version>
+        <maven-shade-plugin.version>3.6.1</maven-shade-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+        <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
     </properties>
 
     <build>
@@ -96,7 +116,7 @@ under the License.
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-eclipse-plugin</artifactId>
-                <version>2.8</version>
+                <version>${maven-eclipse-plugin.version}</version>
                 <configuration>
                     <classpathContainers>
                         <classpathContainer>
@@ -115,13 +135,13 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>${maven-checkstyle-plugin.version}</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
                             <!-- Note: match version with docs/flinkDev/ide_setup.md -->
-                            <version>8.14</version>
+                            <version>${checkstyle.version}</version>
                         </dependency>
                     </dependencies>
                     <executions>
@@ -149,11 +169,11 @@ under the License.
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>
                     <artifactId>spotless-maven-plugin</artifactId>
-                    <version>2.27.1</version>
+                    <version>${spotless-maven-plugin.version}</version>
                     <configuration>
                         <java>
                             <googleJavaFormat>
-                                <version>1.7</version>
+                                <version>${google-java-format.version}</version>
                                 <style>AOSP</style>
                             </googleJavaFormat>
 
@@ -179,7 +199,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M1</version>
+                    <version>${maven-enforcer-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>enforce-maven</id>
@@ -193,7 +213,7 @@ under the License.
                                         <version>[3.1.1,)</version>
                                     </requireMavenVersion>
                                     <requireJavaVersion>
-                                        <version>${target.java.version}</version>
+                                        <version>${maven.compiler.source}</version>
                                     </requireJavaVersion>
                                 </rules>
                             </configuration>
@@ -239,7 +259,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.rat</groupId>
                     <artifactId>apache-rat-plugin</artifactId>
-                    <version>0.13</version>
+                    <version>${apache-rat-plugin.version}</version>
                     <inherited>false</inherited>
                     <executions>
                         <execution>
@@ -308,7 +328,7 @@ under the License.
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>${exec-maven-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>check-license</id>
@@ -335,11 +355,11 @@ under the License.
                     -->
                 </plugin>
 
+                <!-- Configuration for the binary compatibility checker -->
                 <plugin>
-                    <!-- Configuration for the binary compatibility checker -->
-                    <groupId>io.github.zentol.japicmp</groupId>
+                    <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.16.0_m325</version>
+                    <version>${japicmp-maven-plugin.version}</version>
                     <configuration>
                         <oldVersion>
                             <dependency>
@@ -351,9 +371,7 @@ under the License.
                         </oldVersion>
                         <newVersion>
                             <file>
-                                <path>
-                                    ${project.build.directory}/${project.artifactId}-${project.version}.${project.packaging}
-                                </path>
+                                <path>${project.build.directory}/${project.artifactId}-${project.version}.${project.packaging}</path>
                             </file>
                         </newVersion>
                         <parameter>
@@ -361,26 +379,31 @@ under the License.
                             <includes>
                                 <include>@org.apache.flink.annotation.Public</include>
                                 <!-- The following line is un-commented by tools/releasing/update_japicmp_configuration.sh
-                                     as part of the release process -->
+                                    as part of the release process -->
                                 <!--<include>@org.apache.flink.annotation.PublicEvolving</include>-->
                             </includes>
                             <excludes>
+                                <exclude>@java.lang.Deprecated</exclude>
+                                <exclude>*.scala</exclude>
                                 <exclude>@org.apache.flink.annotation.Experimental</exclude>
                                 <exclude>@org.apache.flink.annotation.PublicEvolving</exclude>
                                 <exclude>@org.apache.flink.annotation.Internal</exclude>
+                                <!-- MARKER: start exclusions; these will be wiped by tools/releasing/update_japicmp_configuration.sh -->
+                                <!-- MARKER: end exclusions -->
                             </excludes>
                             <accessModifier>public</accessModifier>
                             <breakBuildOnModifications>false</breakBuildOnModifications>
-                            <breakBuildOnBinaryIncompatibleModifications>true
-                            </breakBuildOnBinaryIncompatibleModifications>
-                            <breakBuildOnSourceIncompatibleModifications>true
-                            </breakBuildOnSourceIncompatibleModifications>
+                            <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+                            <breakBuildOnSourceIncompatibleModifications>true</breakBuildOnSourceIncompatibleModifications>
                             <onlyBinaryIncompatible>false</onlyBinaryIncompatible>
                             <includeSynthetic>true</includeSynthetic>
                             <ignoreMissingClasses>false</ignoreMissingClasses>
                             <skipPomModules>true</skipPomModules>
                             <!-- Don't break build on newly added maven modules -->
                             <ignoreNonResolvableArtifacts>true</ignoreNonResolvableArtifacts>
+                            <packagingSupporteds>
+                                <packagingSupported>jar</packagingSupported>
+                            </packagingSupporteds>
                         </parameter>
                         <projectBuildDir>${rootDir}/${japicmp.outputDir}/${project.artifactId}</projectBuildDir>
                         <dependencies>
@@ -405,10 +428,8 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.0</version>
+                    <version>${maven-compiler-plugin.version}</version>
                     <configuration>
-                        <source>${target.java.version}</source>
-                        <target>${target.java.version}</target>
                         <!-- The semantics of this option are reversed, see MCOMPILER-209. -->
                         <useIncrementalCompilation>false</useIncrementalCompilation>
                         <compilerArgs>
@@ -421,7 +442,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>${maven-jar-plugin.version}</version>
                     <configuration>
                         <archive>
                             <!-- Globally exclude maven metadata, because it may accidentally bundle files we don't intend to -->
@@ -437,7 +458,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>3.5.1</version>
+                    <version>${maven-shade-plugin.version}</version>
                     <configuration>
                         <!-- This section contains the core configuration that is applied to every jar that we create.-->
                         <filters combine.children="append">
@@ -535,7 +556,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.9.1</version>
+                    <version>${maven-javadoc-plugin.version}</version>
                     <configuration>
                         <quiet>true</quiet>
                         <detectOfflineLinks>false</detectOfflineLinks>
@@ -550,7 +571,7 @@ under the License.
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M5</version>
+                    <version>${maven-surefire-plugin.version}</version>
                     <configuration>
                         <!-- enables TCP/IP communication between surefire and forked JVM-->
                         <forkNode implementation="org.apache.maven.plugin.surefire.extensions.SurefireForkNodeFactory"/>
@@ -628,7 +649,7 @@ under the License.
                          Child projects who want to use it must set the ${flink.parent.artifactId} property -->
                     <groupId>org.commonjava.maven.plugins</groupId>
                     <artifactId>directory-maven-plugin</artifactId>
-                    <version>0.1</version>
+                    <version>${directory-maven-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>directories</id>
@@ -649,7 +670,7 @@ under the License.
                 <plugin>
                     <groupId>org.cyclonedx</groupId>
                     <artifactId>cyclonedx-maven-plugin</artifactId>
-                    <version>2.7.3</version>
+                    <version>${cyclonedx-maven-plugin.version}</version>
                     <executions>
                         <execution>
                             <phase>package</phase>
@@ -680,7 +701,7 @@ under the License.
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.2.1</version>
+                        <version>${maven-source-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -717,14 +738,15 @@ under the License.
                 </property>
             </activation>
             <properties>
-                <target.java.version>1.8</target.java.version>
+                <maven.compiler.source>11</maven.compiler.source>
+                <maven.compiler.target>11</maven.compiler.target>
             </properties>
             <build>
                 <plugins>
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.4</version>
+                        <version>${maven-gpg-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -751,7 +773,7 @@ under the License.
                                             <version>[3.2.5,)</version>
                                         </requireMavenVersion>
                                         <requireJavaVersion>
-                                            <version>1.8.0</version>
+                                            <version>${maven.compiler.target}</version>
                                         </requireJavaVersion>
                                     </rules>
                                 </configuration>
@@ -776,7 +798,7 @@ under the License.
                         <plugin>
                             <groupId>org.apache.maven.plugins</groupId>
                             <artifactId>maven-release-plugin</artifactId>
-                            <version>2.1</version>
+                            <version>${maven-release-plugin.version}</version>
                             <configuration>
                                 <mavenExecutorId>forked-path</mavenExecutorId>
                                 <useReleaseProfile>false</useReleaseProfile>
@@ -916,6 +938,7 @@ under the License.
                 </pluginManagement>
             </build>
         </profile>
+
         <profile>
             <id>java21</id>
             <activation>
@@ -940,6 +963,7 @@ under the License.
                 </pluginManagement>
             </build>
         </profile>
+
         <profile>
             <id>java11-target</id>
             <build>
@@ -961,6 +985,7 @@ under the License.
                 </plugins>
             </build>
         </profile>
+
         <profile>
             <id>java17-target</id>
             <build>


### PR DESCRIPTION
To bring the Flink Connectors parent pom in-line with the Flink parent pom, this PR:

* Sets the connector parent pom version to 2.0.0
* Sets the default Java source version to 11 and Java target version to 17
* Sets the release profile to Java source version 11 and Java target version 11
* Moves all the plugin versions into the properties section for easier admin
* Aligns the maven plugin version to flink-parent versions
* Removes Java 8 and adds Java 17 to the CI test matrix
* Update GH Action steps in CI to the latest versions

I was also wondering if there is a reason why we don't just inherit from the flink-parent pom in the connector-parent? It would remove a lot of copy and pasting and aligning of versions.