### PR TITLE
[hotfix][connectors][CI] Replace https://archive.apache.org/ by https://dlcdn.apache.org/ for Flink release download for connectors

### DIFF
--- a/.github/workflows/_testing.yml
+++ b/.github/workflows/_testing.yml
@@ -46,11 +46,11 @@ jobs:
   main-version-with-archunit-tests:
     uses: ./.github/workflows/ci.yml
     with:
-      flink_version: 1.18.0
+      flink_version: 1.18.1
   flink118-java17-version:
     uses: ./.github/workflows/ci.yml
     with:
-      flink_version: 1.18.0
+      flink_version: 1.18.1
       jdk_version: 17
       connector_branch: ci_utils
       run_dependency_convergence: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
               binary_url=https://s3.amazonaws.com/flink-nightly/flink-${{ inputs.flink_version }}-bin-scala_2.12.tgz
               cache_binary=false
             else
-              binary_url=https://archive.apache.org/dist/flink/flink-${{ inputs.flink_version }}/flink-${{ inputs.flink_version }}-bin-scala_2.12.tgz
+              binary_url=https://dlcdn.apache.org/flink/flink-${{ inputs.flink_version }}/flink-${{ inputs.flink_version }}-bin-scala_2.12.tgz
               cache_binary=true
             fi
           else


### PR DESCRIPTION
Replace very slow (that fails the builds because of timeouts) https://archive.apache.org/ by ASF infra recommended https://dlcdn.apache.org/ to download Flink release for connectors to test against.

The job still allows to pass a flink_url only the default inferred url has changed.

Not all the flink releases are available (see https://dlcdn.apache.org/flink/) notably flink 1.18.0 is not so I updated the CI of this CI ( :smile: ) as well