### PR TITLE
Add optional_maven_profiles input to python_ci workflow

### DIFF
--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -42,6 +42,10 @@ on:
         description: "Branch that need to be checked out"
         required: false
         type: string
+      optional_maven_profiles:
+        description: "Optional Maven profiles (passed via -P)."
+        required: false
+        type: string
 
 jobs:
   python_test:
@@ -77,6 +81,10 @@ jobs:
       - name: "Set java11 compile target if required"
         if: ${{ matrix.jdk == 11 }}
         run: echo "MVN_COMMON_OPTIONS=${MVN_COMMON_OPTIONS} -P java11-target" >> $GITHUB_ENV
+
+      - name: "Set optional Maven profiles if required"
+        if: ${{ inputs.optional_maven_profiles != '' }}
+        run: echo "MVN_COMMON_OPTIONS=${MVN_COMMON_OPTIONS} -P ${{ inputs.optional_maven_profiles }}" >> $GITHUB_ENV
 
       - name: Compile
         timeout-minutes: ${{ inputs.timeout_test }}


### PR DESCRIPTION
Add optional_maven_profiles input to python_ci workflow

`ci.yml` already `supports optional_maven_profiles` to allow connectors to activate or deactivate Maven profiles for specific Flink version builds. This change brings `python_ci.yml` to parity.

The input is optional with no default, so all existing callers are unaffected. When provided, the profiles are appended to `MVN_COMMON_OPTIONS` via `-P`, mirroring the existing java11-target pattern.

Motivation: connectors that use Flink-version-gated Maven profiles (e.g. to exclude source files that depend on APIs not available in older Flink versions) need the same gating to apply during the Python CI compile step, not just the Java CI step.                                                                                                                                                                                                                                       
