### PR TITLE
[FLINK-40636][ci] Add Maven and Aether connection timeouts to avoid 50-minute hangs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_global }}
     env:
       MVN_COMMON_OPTIONS: -U -B --no-transfer-progress -Dflink.version=${{ inputs.flink_version }}
-      MVN_CONNECTION_OPTIONS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+      MVN_CONNECTION_OPTIONS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.timeout=60000 -Daether.connector.http.connectionTimeout=60000 -Daether.connector.http.requestTimeout=120000
       FLINK_CACHE_DIR: "/tmp/cache/flink"
       MVN_BUILD_OUTPUT_FILE: "/tmp/mvn_build_output.out"
       MVN_VALIDATION_DIR: "/tmp/flink-validation-deployment"

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -52,7 +52,7 @@ jobs:
     timeout-minutes: ${{ inputs.timeout_global }}
     env:
       MVN_COMMON_OPTIONS: -U -B --no-transfer-progress -Dflink.version=${{ inputs.flink_version }} -DskipTests
-      MVN_CONNECTION_OPTIONS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+      MVN_CONNECTION_OPTIONS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.timeout=60000 -Daether.connector.http.connectionTimeout=60000 -Daether.connector.http.requestTimeout=120000
       MVN_BUILD_OUTPUT_FILE: "/tmp/mvn_build_output.out"
     steps:
       - run: echo "Running CI pipeline for JDK version ${{ matrix.jdk }}"


### PR DESCRIPTION
## What is the purpose of the change

Prevent 50-minute hangs on remote artifact resolution: adds explicit Wagon and Aether network timeouts to `MVN_CONNECTION_OPTIONS`, so a stalled remote repository fails fast instead of hanging for the full job timeout.

## Brief change log

- Added `maven.wagon.http.timeout`, `aether.connector.http.connectionTimeout` and `aether.connector.http.requestTimeout` to `MVN_CONNECTION_OPTIONS` in `.github/workflows/ci.yml` and `.github/workflows/python_ci.yml`

This PR previously also removed `stCarolas/setup-maven@v5` and fixed the cache-save guard; both are dropped from this PR, see the review discussion below.

https://claude.ai/code/session_0168sE9v2tnZHzy9mjDH7PxG
