### PR TITLE
[FLINK-39941][python] Pin virtualenv below 21.5 so py38 tox environments can still be created

### DIFF
--- a/python/lint-python.sh
+++ b/python/lint-python.sh
@@ -278,7 +278,7 @@ function install_tox() {
         fi
     fi
 
-    $CURRENT_DIR/install_command.sh -q tox==3.14.0 2>&1 >/dev/null
+    $CURRENT_DIR/install_command.sh -q tox==3.14.0 "virtualenv<21.5" 2>&1 >/dev/null
     if [ $? -ne 0 ]; then
         echo "uv pip install tox failed \
         please try to exec the script again.\


### PR DESCRIPTION
## What is the purpose of the change

The weekly CI of flink-connector-kafka fails on the v3.4 and v4.0 branches in the `py38-cython` tox environment since 2026-06-14, e.g. [run 34002024546](https://github.com/apache/flink-connector-kafka/actions/runs/34002024546):

```
RuntimeError: the bundled seeder no longer ships pip/setuptools for Python 3.8; the oldest supported target is Python 3.9
ERROR:   py38-cython: InvocationError for command .../.uv/bin/python -m virtualenv --no-download --python .../envs/3.8/bin/python3.8 py38-cython
```

`python/lint-python.sh` installs `tox==3.14.0` into the uv-created Python 3.11 base environment, and tox depends on `virtualenv>=14` without an upper bound. virtualenv 21.5.0 (released 2026-06-13) dropped Python 3.8, so tox can no longer seed the py38 environment. PyFlink 1.20 and 2.0 still declare `Requires-Python >=3.8`, which is why those connector branches keep py38 in their envlist.

## Brief change log

- Add `"virtualenv<21.5"` to the tox install. It resolves to 21.4.3, which runs on the 3.11 base environment and creates 3.8 to 3.13 targets, so the py39 to py311 environments used on newer branches are unaffected.

## Verifying this change

The connector's `flink-python/pom.xml` downloads this script from the `ci_utils` branch at build time, so the fix is exercised by the next weekly run of flink-connector-kafka (`python_test (1.20.5, v3.4)` and `python_test (2.0.2, v4.0)`). Note that 21.4.3 seeds pip 25.0.1, the last pip release for Python 3.8, so this buys time; dropping py38 on those branches (apache/flink-connector-kafka#270) remains the end state.

## Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code 2.1.263 (Claude Fable 5.1)

