### PR TITLE
[FLINK-40629][ci] Keep the license check honest on Maven 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,7 @@ jobs:
       MVN_CONNECTION_OPTIONS: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
       FLINK_CACHE_DIR: "/tmp/cache/flink"
       MVN_BUILD_OUTPUT_FILE: "/tmp/mvn_build_output.out"
+      MVN_LICENSE_OUTPUT_FILE: "/tmp/mvn_license_output.out"
       MVN_VALIDATION_DIR: "/tmp/flink-validation-deployment"
     steps:
       - run: echo "Running CI pipeline for JDK version ${{ matrix.jdk }}"
@@ -184,12 +185,55 @@ jobs:
             -Dlog4j.configurationFile=file://$(pwd)/tools/ci/log4j.properties \
             | tee ${{ env.MVN_BUILD_OUTPUT_FILE }}
 
+      # Maven 3.9 prints mojo banners using the plugin's goal prefix ("deploy:<version>:deploy")
+      # rather than its artifactId ("maven-deploy-plugin:<version>:deploy"). flink-ci-tools'
+      # DeployParser and DependencyParser match on the artifactId spelling, so on Maven 3.9 they
+      # extract 0 modules and the NOTICE half of the license check silently degrades to a no-op
+      # that still exits 0. Rewrite the two affected banners back to the 3.8 spelling.
+      # Remove this step once connectors depend on a flink-ci-tools release containing the parser
+      # fix from FLINK-40459.
+      - name: Normalize Maven 3.9 mojo banners for the license checker
+        run: |
+          sed -E \
+            -e 's/^(\[INFO\] --- )deploy:/\1maven-deploy-plugin:/' \
+            -e 's/^(\[INFO\] --- )dependency:/\1maven-dependency-plugin:/' \
+            ${MVN_BUILD_OUTPUT_FILE} > ${MVN_BUILD_OUTPUT_FILE}.normalized
+          mv ${MVN_BUILD_OUTPUT_FILE}.normalized ${MVN_BUILD_OUTPUT_FILE}
+
       - name: Check licensing
         run: |
+          set -o pipefail
+
+          # Log config for this step only. The repo's tools/ci/log4j.properties differs per
+          # connector and per release branch (some set rootLogger.level = OFF, others shadow
+          # org.apache.flink at WARN), so it cannot be relied on to surface the checker's own
+          # output that the assertion below reads.
+          LICENSE_LOG_CONFIG=$(mktemp -d)/log4j.properties
+          cat > ${LICENSE_LOG_CONFIG} <<'LOG4J'
+          rootLogger.level = WARN
+          rootLogger.appenderRef.console.ref = STDOUT
+          appender.console.name = STDOUT
+          appender.console.type = CONSOLE
+          appender.console.layout.type = PatternLayout
+          appender.console.layout.pattern = %-5p %c{1} - %m%n
+          logger.licensechecker.name = org.apache.flink.tools.ci.licensecheck
+          logger.licensechecker.level = INFO
+          LOG4J
+
           mvn ${MVN_COMMON_OPTIONS} exec:java@check-license -N \
             -Dexec.args="${{ env.MVN_BUILD_OUTPUT_FILE }} $(pwd) ${{ env.MVN_VALIDATION_DIR }}" \
             ${{ env.MVN_CONNECTION_OPTIONS }} \
-            -Dlog4j.configurationFile=file://$(pwd)/tools/ci/log4j.properties
+            -Dlog4j.configurationFile=file://${LICENSE_LOG_CONFIG} \
+            | tee ${MVN_LICENSE_OUTPUT_FILE}
+
+          # A green exit is not evidence that the NOTICE check ran: when the build log cannot be
+          # parsed the checker reports 0 deployed modules, demotes every NOTICE entry to a
+          # TOLERATED "not bundled, but listed" warning and still exits 0. Require a non-zero
+          # module count so a silently skipped check fails the build instead.
+          if ! grep -qE "Extracted [1-9][0-9]* modules that were deployed" ${MVN_LICENSE_OUTPUT_FILE}; then
+            echo "::error::The license check did not inspect any deployed module; refusing to pass it as green."
+            exit 1
+          fi
 
       - name: Print JVM thread dumps when cancelled
         if: ${{ failure() }}

--- a/.github/workflows/python_ci.yml
+++ b/.github/workflows/python_ci.yml
@@ -69,6 +69,13 @@ jobs:
           distribution: 'temurin'
           cache: maven
       
+      - name: Read maven version
+        if: ${{ hashFiles('.mvn/wrapper/maven-wrapper.properties') != '' }}
+        # extract version from property
+        # distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.8.6/apache-maven-3.8.6-bin.zip
+        # => MAVEN_VERSION=3.8.6
+        run: cat .mvn/wrapper/maven-wrapper.properties | grep distributionUrl | grep -o -E "/[0-9]+\.[0-9]+\.[0-9]+/" | tr -d '/' | (echo -n "MAVEN_VERSION=" && cat) >> $GITHUB_ENV
+
       - name: Setup Maven with mvnw version or version 3.8.6
         uses: stCarolas/setup-maven@v5
         with:


### PR DESCRIPTION
## What is the purpose of the change

Prerequisite for bumping connectors to Maven 3.9 (apache/flink-connector-kafka#319, FLINK-40629).

Maven 3.9 prints mojo banners using the plugin's goal prefix (`deploy:3.1.4:deploy`) instead of its artifactId (`maven-deploy-plugin:3.1.4:deploy`). `flink-ci-tools`' `DeployParser` and `DependencyParser` match only the artifactId spelling, and no released `flink-ci-tools` carries the parser fix from FLINK-40459 — the newest on Central is 2.3.0, and connectors pin it to their `flink.version`.

The result is not a build failure. `ShadeParser` keeps working, so shaded-module data is still extracted, but `DeployParser` returns nothing, every shading module counts as "skipping deployment", and `ensureRequiredNoticeFiles` ends up checking nothing. Every NOTICE entry is then reported as "Dependency X is not bundled, but listed" at `Severity.TOLERATED`, which is not counted as severe, so the job stays green. `JarFileChecker` still runs, so it is not a complete no-op — but the NOTICE half drops to zero coverage silently.

Measured on flink-connector-kafka, same tree, only Maven differing:

```
Maven 3.8.6   -> Extracted 4 modules that were deployed and 7 modules which bundle dependencies
Maven 3.9.16  -> Extracted 0 modules that were deployed and 7 modules which bundle dependencies
```

Both exit 0.

## Brief change log

- Rewrite the two affected banners back to the 3.8 spelling before the license check. This is a no-op on Maven 3.8, and flink master's parsers accept both spellings, so it is safe to leave in place during the transition. Removable once connectors depend on a `flink-ci-tools` release containing the FLINK-40459 parser fix.
- Assert a non-zero module count so a check that inspected nothing fails instead of passing.
- Supply a log4j config for the license step rather than reusing the repo's `tools/ci/log4j.properties`. That file differs per connector and per release branch — `flink-connector-jdbc` sets `rootLogger.level = OFF`, and `flink-connector-kafka` `v3.4` and `v4.0` shadow `org.apache.flink` at WARN — so it cannot be relied on to surface the checker's own output that the assertion reads. Without this the assertion would fail healthy builds in those repos.
- Separately: `python_ci.yml` reads `maven-version` from `env.MAVEN_VERSION` but nothing ever sets it, so the Python job always used the hardcoded 3.8.6 fallback while `compile_and_test` used the wrapper's version. Add the "Read maven version" step `ci.yml` already has.

## Verifying this change

Verified against real build logs from flink-connector-kafka, by extracting the step scripts from the workflow and running them:

- Degraded Maven 3.9 log: guard exits 1 (correctly caught).
- Normalised Maven 3.9 log: guard exits 0, and the checker reports the same 4 modules as a 3.8.6 run.
- Maven 3.8.6 baseline log: guard exits 0.
- A `rootLogger.level = OFF` config as used by `flink-connector-jdbc`: with the step-supplied log config the checker's output is present and the guard passes; without it, it would have failed a healthy build.
- The `sed` is byte-identical no-op on a Maven 3.8.6 build log, and is anchored to `^\[INFO\] --- ` so it cannot touch anything else on the line.

## Note for reviewers

Connectors still on Maven 3.8.6 are unaffected: the normalisation matches nothing and the assertion passes as before.

---

##### Was generative AI tooling used to co-author this PR?

- [X] Yes (please specify the tool below)

Generated-by: Claude Code 2.1.267 (Claude Opus 5)